### PR TITLE
feat: Add DXF to PNG converter with Japanese text support

### DIFF
--- a/dxf_converter_colab.ipynb
+++ b/dxf_converter_colab.ipynb
@@ -1,0 +1,276 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# DXF to PNG Converter for Google Colab\n",
+        "\n",
+        "This notebook converts DXF files to PNG format with proper Japanese text handling."
+      ],
+      "metadata": {
+        "id": "header"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install"
+      },
+      "outputs": [],
+      "source": [
+        "# Install required packages\n",
+        "!pip install ezdxf matplotlib\n",
+        "\n",
+        "# Install Japanese fonts\n",
+        "!apt-get update && apt-get install -y fonts-noto-cjk fonts-ipafont-gothic fonts-ipafont-mincho"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Import required libraries\n",
+        "import ezdxf\n",
+        "from ezdxf.addons.drawing import RenderContext, Frontend\n",
+        "from ezdxf.addons.drawing.matplotlib import MatplotlibBackend\n",
+        "import matplotlib.pyplot as plt\n",
+        "import matplotlib.font_manager as fm\n",
+        "import os\n",
+        "from google.colab import files\n",
+        "import io"
+      ],
+      "metadata": {
+        "id": "imports"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Refresh font cache after installing Japanese fonts\n",
+        "fm._rebuild()\n",
+        "\n",
+        "# Setup Japanese font\n",
+        "def setup_japanese_font():\n",
+        "    \"\"\"Setup Japanese font for matplotlib\"\"\"\n",
+        "    japanese_fonts = [\n",
+        "        'Noto Sans CJK JP',\n",
+        "        'IPAGothic',\n",
+        "        'IPAPGothic',\n",
+        "        'IPAMincho',\n",
+        "        'IPAPMincho'\n",
+        "    ]\n",
+        "    \n",
+        "    available_fonts = [f.name for f in fm.fontManager.ttflist]\n",
+        "    \n",
+        "    for font in japanese_fonts:\n",
+        "        if font in available_fonts:\n",
+        "            plt.rcParams['font.family'] = font\n",
+        "            print(f\"Using Japanese font: {font}\")\n",
+        "            return True\n",
+        "    \n",
+        "    print(\"Warning: No Japanese font found\")\n",
+        "    return False\n",
+        "\n",
+        "setup_japanese_font()"
+      ],
+      "metadata": {
+        "id": "setup_font"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def convert_dxf_to_png(dxf_file, png_file, dpi=300):\n",
+        "    \"\"\"\n",
+        "    Convert a DXF file to PNG format\n",
+        "    \n",
+        "    Args:\n",
+        "        dxf_file (str): Path to input DXF file\n",
+        "        png_file (str): Path to output PNG file\n",
+        "        dpi (int): Resolution for PNG output\n",
+        "    \"\"\"\n",
+        "    try:\n",
+        "        # Read DXF file\n",
+        "        print(f\"Reading DXF file: {dxf_file}\")\n",
+        "        doc = ezdxf.readfile(dxf_file)\n",
+        "        \n",
+        "        # Get the modelspace\n",
+        "        msp = doc.modelspace()\n",
+        "        \n",
+        "        # Create rendering context\n",
+        "        context = RenderContext(doc)\n",
+        "        \n",
+        "        # Create matplotlib backend\n",
+        "        backend = MatplotlibBackend(context)\n",
+        "        \n",
+        "        # Create frontend\n",
+        "        frontend = Frontend(context, backend)\n",
+        "        \n",
+        "        # Draw all entities\n",
+        "        frontend.draw_layout(msp)\n",
+        "        \n",
+        "        # Get the figure\n",
+        "        fig = backend.get_figure()\n",
+        "        \n",
+        "        # Set figure size and DPI\n",
+        "        fig.set_dpi(dpi)\n",
+        "        \n",
+        "        # Save to PNG\n",
+        "        print(f\"Saving PNG file: {png_file}\")\n",
+        "        fig.savefig(png_file, dpi=dpi, bbox_inches='tight', pad_inches=0.1)\n",
+        "        \n",
+        "        # Display the result\n",
+        "        plt.figure(figsize=(10, 10))\n",
+        "        img = plt.imread(png_file)\n",
+        "        plt.imshow(img)\n",
+        "        plt.axis('off')\n",
+        "        plt.title(f\"Converted: {png_file}\")\n",
+        "        plt.show()\n",
+        "        \n",
+        "        plt.close('all')\n",
+        "        print(f\"Successfully converted {dxf_file} to {png_file}\")\n",
+        "        \n",
+        "    except Exception as e:\n",
+        "        print(f\"Error converting {dxf_file}: {str(e)}\")\n",
+        "        raise"
+      ],
+      "metadata": {
+        "id": "converter_function"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Upload DXF Files\n",
+        "\n",
+        "Run the cell below to upload your DXF files:"
+      ],
+      "metadata": {
+        "id": "upload_header"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Upload files\n",
+        "uploaded = files.upload()\n",
+        "\n",
+        "# List uploaded files\n",
+        "print(\"Uploaded files:\")\n",
+        "for filename in uploaded.keys():\n",
+        "    print(f\"- {filename}\")"
+      ],
+      "metadata": {
+        "id": "upload_files"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Convert DXF to PNG\n",
+        "\n",
+        "Convert the uploaded DXF files to PNG format:"
+      ],
+      "metadata": {
+        "id": "convert_header"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Convert all uploaded DXF files\n",
+        "for filename in uploaded.keys():\n",
+        "    if filename.endswith('.dxf'):\n",
+        "        output_name = filename.replace('.dxf', '_converted.png')\n",
+        "        convert_dxf_to_png(filename, output_name)"
+      ],
+      "metadata": {
+        "id": "convert_files"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Download Converted Files\n",
+        "\n",
+        "Download the converted PNG files:"
+      ],
+      "metadata": {
+        "id": "download_header"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Download all PNG files\n",
+        "import glob\n",
+        "\n",
+        "png_files = glob.glob('*_converted.png')\n",
+        "for png_file in png_files:\n",
+        "    print(f\"Downloading: {png_file}\")\n",
+        "    files.download(png_file)"
+      ],
+      "metadata": {
+        "id": "download_files"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Alternative: Convert Specific Files\n",
+        "\n",
+        "If you have test_file1.dxf and test_file2.dxf:"
+      ],
+      "metadata": {
+        "id": "alternative_header"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Convert specific test files\n",
+        "test_files = [\n",
+        "    (\"test_file1.dxf\", \"test_file1_converted.png\"),\n",
+        "    (\"test_file2.dxf\", \"test_file2_converted.png\")\n",
+        "]\n",
+        "\n",
+        "for dxf_file, png_file in test_files:\n",
+        "    if os.path.exists(dxf_file):\n",
+        "        convert_dxf_to_png(dxf_file, png_file)\n",
+        "    else:\n",
+        "        print(f\"{dxf_file} not found\")"
+      ],
+      "metadata": {
+        "id": "convert_specific"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/dxf_to_png_converter.py
+++ b/dxf_to_png_converter.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+DXF to PNG converter using ezdxf library
+This script converts DXF files to PNG format with proper Japanese text handling
+"""
+
+import ezdxf
+from ezdxf.addons.drawing import RenderContext, Frontend
+from ezdxf.addons.drawing.matplotlib import MatplotlibBackend
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+import os
+import sys
+
+# For Google Colab environment
+try:
+    import google.colab
+    IN_COLAB = True
+except ImportError:
+    IN_COLAB = False
+
+def setup_japanese_font():
+    """
+    Setup Japanese font for matplotlib to handle Japanese text properly
+    Returns the font properties object
+    """
+    # Common Japanese fonts that might be available
+    japanese_fonts = [
+        'Noto Sans CJK JP',
+        'IPAGothic',
+        'IPAPGothic',
+        'IPAMincho',
+        'IPAPMincho',
+        'TakaoGothic',
+        'TakaoPGothic',
+        'Yu Gothic',
+        'Hiragino Sans',
+        'MS Gothic',
+        'MS PGothic'
+    ]
+    
+    # Try to find an available Japanese font
+    available_fonts = [f.name for f in fm.fontManager.ttflist]
+    font_prop = None
+    
+    for font in japanese_fonts:
+        if font in available_fonts:
+            font_prop = fm.FontProperties(family=font)
+            print(f"Using Japanese font: {font}")
+            break
+    
+    if font_prop is None:
+        print("Warning: No Japanese font found. Japanese text may not display correctly.")
+        print("Available fonts:", sorted(set(available_fonts))[:10], "...")
+        
+        # In Google Colab, install Japanese fonts
+        if IN_COLAB:
+            print("Installing Japanese fonts for Google Colab...")
+            os.system('apt-get update && apt-get install -y fonts-noto-cjk')
+            # Refresh font cache
+            fm._rebuild()
+            # Try again
+            available_fonts = [f.name for f in fm.fontManager.ttflist]
+            for font in japanese_fonts:
+                if font in available_fonts:
+                    font_prop = fm.FontProperties(family=font)
+                    print(f"Using Japanese font after installation: {font}")
+                    break
+    
+    return font_prop
+
+def convert_dxf_to_png(dxf_file, png_file, dpi=300):
+    """
+    Convert a DXF file to PNG format
+    
+    Args:
+        dxf_file (str): Path to input DXF file
+        png_file (str): Path to output PNG file
+        dpi (int): Resolution for PNG output (default: 300)
+    """
+    try:
+        # Setup Japanese font
+        font_prop = setup_japanese_font()
+        
+        # Read DXF file
+        print(f"Reading DXF file: {dxf_file}")
+        doc = ezdxf.readfile(dxf_file)
+        
+        # Get the modelspace
+        msp = doc.modelspace()
+        
+        # Create rendering context
+        context = RenderContext(doc)
+        
+        # Create matplotlib backend
+        backend = MatplotlibBackend(context)
+        
+        # Configure matplotlib for Japanese text
+        if font_prop:
+            plt.rcParams['font.family'] = font_prop.get_family()
+        
+        # Create frontend
+        frontend = Frontend(context, backend)
+        
+        # Draw all entities
+        frontend.draw_layout(msp)
+        
+        # Get the figure
+        fig = backend.get_figure()
+        
+        # Set figure size and DPI for good quality
+        fig.set_dpi(dpi)
+        
+        # Save to PNG
+        print(f"Saving PNG file: {png_file}")
+        fig.savefig(png_file, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
+        plt.close(fig)
+        
+        print(f"Successfully converted {dxf_file} to {png_file}")
+        
+    except Exception as e:
+        print(f"Error converting {dxf_file}: {str(e)}")
+        raise
+
+def main():
+    """
+    Main function to convert test DXF files
+    """
+    # List of files to convert
+    files_to_convert = [
+        ("test_file1.dxf", "test_file1_converted.png"),
+        ("test_file2.dxf", "test_file2_converted.png")
+    ]
+    
+    # Check if running in Google Colab
+    if IN_COLAB:
+        print("Running in Google Colab environment")
+        # Mount Google Drive if needed
+        # from google.colab import drive
+        # drive.mount('/content/drive')
+    
+    # Convert each file
+    for dxf_file, png_file in files_to_convert:
+        if os.path.exists(dxf_file):
+            convert_dxf_to_png(dxf_file, png_file)
+        else:
+            print(f"Warning: {dxf_file} not found, skipping...")
+    
+    print("\nConversion completed!")
+
+if __name__ == "__main__":
+    # Install required packages if in Google Colab
+    if IN_COLAB:
+        print("Installing required packages...")
+        os.system('pip install ezdxf matplotlib')
+    
+    main()

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,0 +1,94 @@
+# DXF to PNG Converter - Implementation Notes
+
+## 実装内容 (What I Implemented)
+
+DXFファイルをPNG形式に変換するPythonスクリプトを作成しました。以下の2つのバージョンを提供：
+
+1. **dxf_to_png_converter.py** - 通常のPythonスクリプト
+2. **dxf_converter_colab.ipynb** - Google Colab用のJupyterノートブック
+
+## 使用したライブラリ (Libraries Used)
+
+- **ezdxf**: DXFファイルの読み込みと解析
+- **matplotlib**: 画像のレンダリングとPNG出力
+- **matplotlib.font_manager**: 日本語フォントの管理
+
+## 日本語文字化け対策 (Japanese Text Handling)
+
+### 問題点 (Issues)
+- デフォルトのmatplotlibフォントは日本語をサポートしていない
+- 日本語テキストが□□□（豆腐）として表示される
+
+### 解決方法 (Solutions)
+1. **日本語フォントの自動検出**
+   - Noto Sans CJK JP, IPAGothic, IPAMincho等の一般的な日本語フォントを検索
+   - 利用可能なフォントを自動的に選択
+
+2. **Google Colab環境での対応**
+   - fonts-noto-cjkパッケージを自動インストール
+   - フォントキャッシュを更新して新しいフォントを認識
+
+3. **フォールバック処理**
+   - 日本語フォントが見つからない場合は警告を表示
+   - 利用可能なフォントリストを表示してデバッグを支援
+
+## 実装の詳細 (Implementation Details)
+
+### 基本的な変換プロセス
+```python
+1. DXFファイルを読み込む (ezdxf.readfile)
+2. モデルスペースを取得
+3. レンダリングコンテキストを作成
+4. Matplotlibバックエンドでレンダリング
+5. 高解像度(300 DPI)でPNGとして保存
+```
+
+### Google Colab対応
+- ファイルアップロード機能
+- 変換結果のプレビュー表示
+- 自動ダウンロード機能
+
+## 使用方法 (How to Use)
+
+### 通常のPython環境
+```bash
+# 必要なパッケージをインストール
+pip install ezdxf matplotlib
+
+# スクリプトを実行
+python dxf_to_png_converter.py
+```
+
+### Google Colab
+1. dxf_converter_colab.ipynbをColabで開く
+2. セルを順番に実行
+3. DXFファイルをアップロード
+4. 変換されたPNGファイルをダウンロード
+
+## 注意事項 (Notes)
+
+- DXFファイルの複雑さによっては、完璧な変換ができない場合があります
+- 特殊なCADエンティティ（ブロック、外部参照等）は簡略化される可能性があります
+- 日本語フォントがインストールされていない環境では、事前にフォントのインストールが必要です
+
+## トラブルシューティング (Troubleshooting)
+
+### 日本語が表示されない場合
+1. 日本語フォントをインストール：
+   ```bash
+   # Ubuntu/Debian
+   sudo apt-get install fonts-noto-cjk
+   
+   # または
+   sudo apt-get install fonts-ipafont-gothic fonts-ipafont-mincho
+   ```
+
+2. フォントキャッシュを更新：
+   ```python
+   import matplotlib.font_manager as fm
+   fm._rebuild()
+   ```
+
+### メモリ不足エラー
+- 大きなDXFファイルの場合、DPIを下げる（例：150）
+- バッチ処理ではなく、1ファイルずつ処理する


### PR DESCRIPTION
Closes #2

## Summary

Implemented DXF to PNG converter with proper Japanese text handling as requested.

## Changes
- Created Python script for DXF to PNG conversion using ezdxf
- Added Google Colab notebook for web-based conversion
- Implemented automatic Japanese font detection and setup
- Added comprehensive documentation in Japanese and English

## Note
These files should be moved to the backend-coding-test branch as originally requested.

Generated with [Claude Code](https://claude.ai/code)